### PR TITLE
Fix resource numeration to avoid overlapping with PMOD.

### DIFF
--- a/nmigen_boards/icebreaker.py
+++ b/nmigen_boards/icebreaker.py
@@ -22,7 +22,7 @@ class ICEBreakerPlatform(LatticeICE40Platform):
         Resource("user_ledr", 0, PinsN("11", dir="o"), Attrs(IO_STANDARD="SB_LVCMOS33")),
         Resource("user_ledg", 0, PinsN("37", dir="o"), Attrs(IO_STANDARD="SB_LVCMOS33")),
 
-        Resource("user_btn",  4, PinsN("10", dir="i"), Attrs(IO_STANDARD="SB_LVCMOS33")),
+        Resource("user_btn",  0, PinsN("10", dir="i"), Attrs(IO_STANDARD="SB_LVCMOS33")),
 
         Resource("serial", 0,
             Subsignal("rx",  Pins("6", dir="i")),
@@ -45,22 +45,22 @@ class ICEBreakerPlatform(LatticeICE40Platform):
     # p.add_resources(p.break_off_pmod)
     # pmod_btn = plat.request("user_btn")
     break_off_pmod = [
-         Resource("user_btn", 0, Pins("9", dir="i", conn=("pmod", 2)), Attrs(IO_STANDARD="SB_LVCMOS33")),
-         Resource("user_btn", 1, Pins("4",  dir="i", conn=("pmod", 2)), Attrs(IO_STANDARD="SB_LVCMOS33")),
-         Resource("user_btn", 2, Pins("10",  dir="i", conn=("pmod", 2)), Attrs(IO_STANDARD="SB_LVCMOS33")),
+         Resource("user_btn", 1, Pins("9", dir="i", conn=("pmod", 2)), Attrs(IO_STANDARD="SB_LVCMOS33")),
+         Resource("user_btn", 2, Pins("4",  dir="i", conn=("pmod", 2)), Attrs(IO_STANDARD="SB_LVCMOS33")),
+         Resource("user_btn", 3, Pins("10",  dir="i", conn=("pmod", 2)), Attrs(IO_STANDARD="SB_LVCMOS33")),
 
-         Resource("user_led", 0, Pins("7", dir="o", conn=("pmod", 2)), Attrs(IO_STANDARD="SB_LVCMOS33")),
-         Resource("user_led", 1, Pins("1", dir="o", conn=("pmod", 2)), Attrs(IO_STANDARD="SB_LVCMOS33")),
-         Resource("user_led", 2, Pins("2", dir="o", conn=("pmod", 2)), Attrs(IO_STANDARD="SB_LVCMOS33")),
-         Resource("user_led", 3, Pins("8", dir="o", conn=("pmod", 2)), Attrs(IO_STANDARD="SB_LVCMOS33")),
-         Resource("user_led", 4, Pins("3", dir="o", conn=("pmod", 2)), Attrs(IO_STANDARD="SB_LVCMOS33")),
+         Resource("user_led", 2, Pins("7", dir="o", conn=("pmod", 2)), Attrs(IO_STANDARD="SB_LVCMOS33")),
+         Resource("user_led", 3, Pins("1", dir="o", conn=("pmod", 2)), Attrs(IO_STANDARD="SB_LVCMOS33")),
+         Resource("user_led", 4, Pins("2", dir="o", conn=("pmod", 2)), Attrs(IO_STANDARD="SB_LVCMOS33")),
+         Resource("user_led", 5, Pins("8", dir="o", conn=("pmod", 2)), Attrs(IO_STANDARD="SB_LVCMOS33")),
+         Resource("user_led", 6, Pins("3", dir="o", conn=("pmod", 2)), Attrs(IO_STANDARD="SB_LVCMOS33")),
 
          # Color-specific aliases
-         Resource("user_ledr", 0, Pins("7", dir="o", conn=("pmod", 2)), Attrs(IO_STANDARD="SB_LVCMOS33")),
-         Resource("user_ledg", 0, Pins("1", dir="o", conn=("pmod", 2)), Attrs(IO_STANDARD="SB_LVCMOS33")),
-         Resource("user_ledg", 1, Pins("2", dir="o", conn=("pmod", 2)), Attrs(IO_STANDARD="SB_LVCMOS33")),
-         Resource("user_ledg", 2, Pins("8", dir="o", conn=("pmod", 2)), Attrs(IO_STANDARD="SB_LVCMOS33")),
-         Resource("user_ledg", 3, Pins("3", dir="o", conn=("pmod", 2)), Attrs(IO_STANDARD="SB_LVCMOS33"))
+         Resource("user_ledr", 1, Pins("7", dir="o", conn=("pmod", 2)), Attrs(IO_STANDARD="SB_LVCMOS33")),
+         Resource("user_ledg", 1, Pins("1", dir="o", conn=("pmod", 2)), Attrs(IO_STANDARD="SB_LVCMOS33")),
+         Resource("user_ledg", 2, Pins("2", dir="o", conn=("pmod", 2)), Attrs(IO_STANDARD="SB_LVCMOS33")),
+         Resource("user_ledg", 3, Pins("8", dir="o", conn=("pmod", 2)), Attrs(IO_STANDARD="SB_LVCMOS33")),
+         Resource("user_ledg", 4, Pins("3", dir="o", conn=("pmod", 2)), Attrs(IO_STANDARD="SB_LVCMOS33"))
     ]
 
     def toolchain_program(self, products, name):


### PR DESCRIPTION
Currently when you add `plat.add_resources(plat.break_off_pmod)` there is a build error
```
NameError: Trying to add (resource user_led 0 (pins o pmod_2:7) (attrs IO_STANDARD=SB_LVCMOS33)), but (resource user_led 0 (pins-n o 11) (attrs IO_STANDA
RD=SB_LVCMOS33)) has the same name and number
```
It is caused by overlapping resource indices in icebreaker.py board description.
In order to address this issue numeration has changed to be contiguous.
For example, `user_led` on main board have indices 0 and 1 and PMOD `user_led` are now assigned to numbers from 2 to 6. Similar adjustments are made to `user_ledr`, `user_ledg` and `user_btn`