### PR TITLE
tinyfpga_bx: fix definition of io pin 17

### DIFF
--- a/nmigen_boards/tinyfpga_bx.py
+++ b/nmigen_boards/tinyfpga_bx.py
@@ -38,7 +38,7 @@ class TinyFPGABXPlatform(LatticeICE40Platform):
              "   A2 A1 B1 C2 C1 D2 D1 E2 E1 G2 H1 J1 H2 "
             # Right side of the board
             #          14 15 16 17 18 19 20 21 22 23 24
-             "         H9 D9 D8 B8 A9 B8 A8 B7 A7 B6 A6 "
+             "         H9 D9 D8 C9 A9 B8 A8 B7 A7 B6 A6 "
             # Bottom of the board
             # 25 26 27 28 29 30 31
              "G1 J3 J4 G9 J9 E8 J2"


### PR DESCRIPTION
As in https://github.com/tinyfpga/TinyFPGA-BX/blob/master/icestorm_template/pins.pcf#L59, pin 17 should be C9 instead of pin 17/19 both being B8. This caused issues when using both pins 17/19 in a design.